### PR TITLE
Use Joda-Time to parse and print ISO8601 strings

### DIFF
--- a/onedriveaccess/build.gradle
+++ b/onedriveaccess/build.gradle
@@ -41,4 +41,5 @@ dependencies {
     compile 'com.squareup.retrofit:retrofit:1.9.0'
     compile 'com.squareup.okhttp:okhttp:2.0.0'
     compile 'com.squareup.okhttp:okhttp-urlconnection:2.0.0'
+    compile 'joda-time:joda-time:2.4'
 }

--- a/onedriveaccess/src/main/java/com/microsoft/onedriveaccess/GsonFactory.java
+++ b/onedriveaccess/src/main/java/com/microsoft/onedriveaccess/GsonFactory.java
@@ -69,7 +69,7 @@ final class GsonFactory {
                     return null;
                 }
                 try {
-                    return ISO8601.toCalendar(json.getAsString());
+                    return ISO8601.toDate(json.getAsString());
                 } catch (final ParseException e) {
                     Log.e("JsonDeserializerDate", "Parsing issue on " + json.getAsString() + " ! " + e.toString());
                     return null;

--- a/onedriveaccess/src/main/java/com/microsoft/onedriveaccess/ISO8601.java
+++ b/onedriveaccess/src/main/java/com/microsoft/onedriveaccess/ISO8601.java
@@ -1,15 +1,14 @@
 package com.microsoft.onedriveaccess;
 
-import android.annotation.SuppressLint;
+import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
 
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.Date;
 
 /**
  * Helper class for handling ISO 8601 strings of the following format: "2008-03-01T13:00:00".
- * @author wrygiel
- * @see http://stackoverflow.com/a/10621553/533057
  */
 final class ISO8601 {
 
@@ -30,9 +29,10 @@ final class ISO8601 {
      * @param date to convert
      * @return the date as an ISO 8601 string
      */
-    @SuppressLint("SimpleDateFormat")
     public static String fromDate(final Date date) {
-        return new SimpleDateFormat(DATE_FORMAT_STRING).format(date);
+        final DateTimeFormatter formatter = DateTimeFormat.forPattern(DATE_FORMAT_STRING);
+        final DateTime dateTime = new DateTime(date);
+        return formatter.print(dateTime);
     }
 
     /**
@@ -41,15 +41,9 @@ final class ISO8601 {
      * @return the date
      * @exception ParseException If the date could not be parsed
      */
-    @SuppressLint("SimpleDateFormat")
-    public static Date toCalendar(final String iso8601string)
+    public static Date toDate(final String iso8601string)
             throws ParseException {
-        String s = iso8601string;
-        try {
-            s = s.substring(0, 22) + s.substring(23);  // to get rid of the ":"
-        } catch (final IndexOutOfBoundsException e) {
-            throw new ParseException("Invalid length", 0);
-        }
-        return new SimpleDateFormat(DATE_FORMAT_STRING).parse(s);
+        final DateTimeFormatter formatter = DateTimeFormat.forPattern(DATE_FORMAT_STRING);
+        return formatter.parseDateTime(iso8601string).toDate();
     }
 }


### PR DESCRIPTION
Fixes https://github.com/OneDrive/onedrive-explorer-android/issues/5

Thanks for the contribution @davidtamayo177 https://github.com/OneDrive/onedrive-explorer-android/pull/23 I've cleaned this up a little to use the gradle imports and follow the style standards of the repository