### PR TITLE
Newest version of wuman oauth doesn't require touching WebKit directly

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,7 +37,7 @@ task checkstyle(type: Checkstyle) {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.wu-man:android-oauth-client:0.0.3'
+    compile 'com.wu-man:android-oauth-client:0.4.5'
     compile 'com.mcxiaoke.volley:library:1.0.15'
     compile project(':onedriveaccess')
 }

--- a/app/src/main/java/com/microsoft/onedrive/apiexplorer/BaseApplication.java
+++ b/app/src/main/java/com/microsoft/onedrive/apiexplorer/BaseApplication.java
@@ -202,6 +202,16 @@ public class BaseApplication extends Application {
             }
 
             @Override
+            public boolean disableWebViewCache() {
+                return false;
+            }
+
+            @Override
+            public boolean removePreviousCookie() {
+                return true;
+            }
+
+            @Override
             public String getRedirectUri() throws IOException {
                 return liveDesktopRedirectEndpoint;
             }

--- a/app/src/main/java/com/microsoft/onedrive/apiexplorer/BaseApplication.java
+++ b/app/src/main/java/com/microsoft/onedrive/apiexplorer/BaseApplication.java
@@ -1,14 +1,10 @@
 package com.microsoft.onedrive.apiexplorer;
 
-import android.annotation.SuppressLint;
-import android.annotation.TargetApi;
 import android.app.Application;
 import android.app.FragmentManager;
 import android.graphics.Bitmap;
-import android.os.Build;
 import android.util.Log;
 import android.util.LruCache;
-import android.webkit.CookieManager;
 
 import com.android.volley.RequestQueue;
 import com.android.volley.toolbox.ImageLoader;
@@ -195,7 +191,7 @@ public class BaseApplication extends Application {
         final String liveDesktopRedirectEndpoint = getString(R.string.base_auth_endpoint)
                 + getString(R.string.url_path_desktop);
 
-        return new DialogFragmentController(fragmentManager) {
+        return new DialogFragmentController(fragmentManager, true) {
             @Override
             public boolean isJavascriptEnabledForWebView() {
                 return true;

--- a/app/src/main/java/com/microsoft/onedrive/apiexplorer/BaseApplication.java
+++ b/app/src/main/java/com/microsoft/onedrive/apiexplorer/BaseApplication.java
@@ -163,35 +163,12 @@ public class BaseApplication extends Application {
         try {
             final Credential credential = new GoogleCredential();
             mCredentialStore.delete(USER_ID, credential);
-            clearCookies();
         } catch (final IOException ignored) {
             // Ignored
             Log.d(getClass().getSimpleName(), ignored.toString());
         }
 
         mAuthorizationFlow = null;
-    }
-
-    /**
-     * Clears all cookies from this applications web views
-     */
-    @SuppressWarnings("deprecation")
-    private void clearCookies() {
-        CookieManager mgr = CookieManager.getInstance();
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            clearCookies21(mgr);
-        } else {
-            mgr.removeAllCookie();
-        }
-    }
-
-    /**
-     * Clears all cookies from this applications web views on Lollipop+
-     * @param mgr The cookie manager to clear of saved cookies
-     */
-    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
-    private void clearCookies21(final CookieManager mgr) {
-        mgr.removeAllCookies(null);
     }
 
     /**


### PR DESCRIPTION
New impl of DialogFragmentController has a ```removePreviousCookie()``` method which handles the Cookie purge automatically.

Also the WebView which presents the login + consent is now full screen.