### PR TITLE
Deal with a broader ranges of possible time values

### DIFF
--- a/onedriveaccess/src/androidTest/java/com/microsoft/onedriveaccess/ISO8601Test.java
+++ b/onedriveaccess/src/androidTest/java/com/microsoft/onedriveaccess/ISO8601Test.java
@@ -20,10 +20,10 @@ public class ISO8601Test extends AndroidTestCase {
         // I sure hope this works in other timezones...
         TimeZone.setDefault(TimeZone.getTimeZone("PST"));
         final Date date = new Date(123456789012345L);
-        Assert.assertEquals("5882-03-11T00:30:12.345+0000", ISO8601.fromDate(date));
+        Assert.assertEquals("5882-03-11T00:30:12.345Z", ISO8601.fromDate(date));
 
         final Date dateNoMillis = new Date(123456789012000L);
-        Assert.assertEquals("5882-03-11T00:30:12.000+0000", ISO8601.fromDate(dateNoMillis));
+        Assert.assertEquals("5882-03-11T00:30:12.000Z", ISO8601.fromDate(dateNoMillis));
     }
 
     /**
@@ -32,10 +32,15 @@ public class ISO8601Test extends AndroidTestCase {
      */
     public void testToDate() throws Exception {
         TimeZone.setDefault(TimeZone.getTimeZone("PST"));
-        final Date date = new Date(123456789012345L);
-        Assert.assertEquals(date, ISO8601.toDate("5882-03-11T00:30:12.345+0000"));
+        final long toTheSecondDate = 123456789012000L;
+        final Date dateToSecond = ISO8601.toDate("5882-03-11T00:30:12Z");
+        Assert.assertEquals(toTheSecondDate, dateToSecond.getTime());
 
-        final Date dateNoMillis = new Date(123456789012000L);
-        Assert.assertEquals(dateNoMillis, ISO8601.toDate("5882-03-11T00:30:12+0000"));
+        final long toTheMillisecondDate = 123456789012345L;
+        final Date dateToTheMillisecond = ISO8601.toDate("5882-03-11T00:30:12.345Z");
+        Assert.assertEquals(toTheMillisecondDate, dateToTheMillisecond.getTime());
+
+        final Date dateToTheExtremeMillisecond = ISO8601.toDate("5882-03-11T00:30:12.3456789Z");
+        Assert.assertEquals(toTheMillisecondDate, dateToTheExtremeMillisecond.getTime());
     }
 }

--- a/onedriveaccess/src/main/java/com/microsoft/onedriveaccess/ISO8601.java
+++ b/onedriveaccess/src/main/java/com/microsoft/onedriveaccess/ISO8601.java
@@ -3,25 +3,21 @@ package com.microsoft.onedriveaccess;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.DateTimeFormatterBuilder;
+import org.joda.time.format.DateTimeParser;
+import org.joda.time.format.ISODateTimeFormat;
 
 import java.text.ParseException;
 import java.util.Date;
 
 /**
- * Helper class for handling ISO 8601 strings of the following format: "2008-03-01T13:00:00".
+ * Helper class for handling ISO 8601 strings of the format: "2008-03-01T13:00:00.123Z".
  */
 final class ISO8601 {
-
     /**
-     * The ISO8601 date format string, see https://en.wikipedia.org/wiki/ISO_8601
-     * Modified slightly to match the OData response from OneDrive
+     * The datetime formatter which can deal with second/millisecond/extreme millisecond value dates
      */
-    public static final String DATE_FORMAT_MILLIS_STRING = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
-
-    /**
-     * Same as DATE_FORMAT_MILLIS_STRING without the millis
-     */
-    public static final String DATE_FORMAT_STRING = "yyyy-MM-dd'T'HH:mm:ssZ";
+    private static DateTimeFormatter mFormatter;
 
     /**
      * Default constructor
@@ -35,7 +31,7 @@ final class ISO8601 {
      * @return the date as an ISO 8601 string
      */
     public static String fromDate(final Date date) {
-        final DateTimeFormatter formatter = DateTimeFormat.forPattern(DATE_FORMAT_MILLIS_STRING);
+        final DateTimeFormatter formatter = ISODateTimeFormat.dateTime();
         final DateTime dateTime = new DateTime(date);
         return formatter.print(dateTime);
     }
@@ -48,12 +44,20 @@ final class ISO8601 {
      */
     public static Date toDate(final String iso8601string)
             throws ParseException {
-        try {
-            final DateTimeFormatter formatter = DateTimeFormat.forPattern(DATE_FORMAT_MILLIS_STRING);
-            return formatter.parseDateTime(iso8601string).toDate();
-        } catch (final IllegalArgumentException ex) {
-            final DateTimeFormatter formatter = DateTimeFormat.forPattern(DATE_FORMAT_STRING);
-            return formatter.parseDateTime(iso8601string).toDate();
+        if (mFormatter == null) {
+            mFormatter = new DateTimeFormatterBuilder()
+                    .append(ISODateTimeFormat.date())
+                    .appendLiteral('T')
+                    .append(ISODateTimeFormat.hourMinuteSecond())
+                    .appendOptional(new DateTimeFormatterBuilder()
+                            .appendLiteral('.')
+                            .appendFractionOfSecond(3, 9)
+                            .toParser())
+                    .appendTimeZoneOffset("Z", true, 2, 4)
+                    .toFormatter()
+                    .withZoneUTC();
         }
+
+        return mFormatter.parseDateTime(iso8601string).toDate();
     }
 }


### PR DESCRIPTION
Instead of using the fallback system between different parsers, just
create a custom formatter that is able to internally manage optional
elements to the format.