### PR TITLE
Support pause/resuming thumbnail downloads

### DIFF
--- a/app/src/main/java/com/microsoft/onedrive/apiexplorer/DisplayItemAdapter.java
+++ b/app/src/main/java/com/microsoft/onedrive/apiexplorer/DisplayItemAdapter.java
@@ -61,6 +61,7 @@ public class DisplayItemAdapter extends ArrayAdapter<DisplayItem> {
         }
 
         final DisplayItem item = getItem(position);
+        item.resumeThumbnailDownload();
 
         ((TextView)view.findViewById(android.R.id.text1)).setText(item.getItem().name);
         ((TextView)view.findViewById(android.R.id.text2)).setText(item.getTypeFacets());
@@ -75,5 +76,11 @@ public class DisplayItemAdapter extends ArrayAdapter<DisplayItem> {
 
 
         return view;
+    }
+
+    public void stopDownloadingThumbnails() {
+        for (int i = 0; i < getCount(); i++) {
+            getItem(i).cancelThumbnailDownload();
+        }
     }
 }

--- a/app/src/main/java/com/microsoft/onedrive/apiexplorer/ItemFragment.java
+++ b/app/src/main/java/com/microsoft/onedrive/apiexplorer/ItemFragment.java
@@ -141,7 +141,7 @@ public class ItemFragment extends Fragment implements AbsListView.OnItemClickLis
      * The Adapter which will be used to populate the ListView/GridView with
      * Views.
      */
-    private ListAdapter mAdapter;
+    private DisplayItemAdapter mAdapter;
 
     /**
      * If the current fragment should prioritize the empty view over the visualization
@@ -393,6 +393,12 @@ public class ItemFragment extends Fragment implements AbsListView.OnItemClickLis
         }
     }
 
+    @Override
+    public void onPause() {
+        super.onPause();
+        mAdapter.stopDownloadingThumbnails();
+    }
+
     /**
      * Creates a callback for drilling into an item
      * @param context The application context to display messages
@@ -538,9 +544,9 @@ public class ItemFragment extends Fragment implements AbsListView.OnItemClickLis
                             @Override
                             public void success(final Void response) {
                                 Toast.makeText(getActivity(),
-                                                  application.getString(R.string.deleted_this_item,
-                                                                           item.name),
-                                                  Toast.LENGTH_LONG).show();
+                                        application.getString(R.string.deleted_this_item,
+                                                item.name),
+                                        Toast.LENGTH_LONG).show();
                                 getActivity().onBackPressed();
                             }
                         });
@@ -868,6 +874,7 @@ public class ItemFragment extends Fragment implements AbsListView.OnItemClickLis
      * @param fragment the fragment to navigate into
      */
     private void navigateToFragment(final Fragment fragment) {
+        mAdapter.stopDownloadingThumbnails();
         getFragmentManager()
             .beginTransaction()
             .add(R.id.fragment, fragment)


### PR DESCRIPTION
AsyncTask's queue backs up if there are a bunch of thumbnail requests in
flight, this will make the UX more responsive, and if you navigate back to
a view that contains a thumbnail paused, the download will be resumed.