### PR TITLE
Fix Start Browsing Button on back

### DIFF
--- a/app/src/main/java/com/microsoft/onedrive/apiexplorer/PlaceholderFragment.java
+++ b/app/src/main/java/com/microsoft/onedrive/apiexplorer/PlaceholderFragment.java
@@ -71,6 +71,7 @@ public class PlaceholderFragment extends Fragment {
                 };
                 try {
                     app.getOneDriveClient();
+                    navigateToRoot();
                     button.setEnabled(true);
                 } catch (final UnsupportedOperationException ignored) {
                     app.createOneDriveClient(getActivity(), serviceCreated);


### PR DESCRIPTION
The "Start Browsing Your OneDrive" button was checking for the existance
of the service object and then if it saw an expection was creating the
service object and sending the user to the root of their OneDrive.  This
unforunately would not work in the success case where a service object
existed, adding in the proper navigateToRoot call in the success flow.
Fixes #68.